### PR TITLE
Fix killing executable

### DIFF
--- a/remarkable_sim/sim.py
+++ b/remarkable_sim/sim.py
@@ -201,8 +201,7 @@ class GUI(object):
         self.fifo_button = makefifo(path_fifo_button)
 
         if executable is not None:
-            # prepend exec so that executable inherits shell process and can be killed
-            self.subprocess = subprocess.Popen('exec ' + executable, shell=True)
+            self.subprocess = subprocess.Popen(executable)
         else:
             self.subprocess = None
 
@@ -331,6 +330,7 @@ def main():
 
     if gui.subprocess is not None:
         gui.subprocess.terminate()
+        gui.subprocess.wait()
     os.remove(path_fifo_stylus)
     os.remove(path_fifo_touch)
     os.remove(path_fifo_button)


### PR DESCRIPTION
When using this to try to execute an application through a script that passes arguments to the final executable, it would fail to kill the executable when quitting the simulator. This change makes sure it exits, and waits for it.